### PR TITLE
Add common interface on generated Databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ captures/
 # Intellij
 *.iml
 .idea/workspace.xml
+.idea
 
 # Keystore files
 *.jks

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ captures/
 
 # Intellij
 *.iml
-.idea/workspace.xml
 .idea
 
 # Keystore files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
          classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 09 16:38:19 CET 2017
+#Tue May 09 19:39:58 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Constants.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Constants.java
@@ -20,6 +20,7 @@ public class Constants {
 
     public static final String DAO_CLASS_NAME = "RxAndroidOrm";
     public static final String DATABASE_HELPER_CLASS_NAME = "DatabaseHelper";
+    public static final String DATABASE_COMMON_INTERFACE_NAME = "Database";
     public static final String MIGRATOR = "Migrator";
     public static final String CALLBACK = "Callback";
 
@@ -35,6 +36,7 @@ public class Constants {
 
     public static final TypeName applicationClassName = ClassName.get("android.app", "Application");
     public static final TypeName databaseClassName = ClassName.get("android.database.sqlite", "SQLiteDatabase");
+    public static final TypeName databaseCommonInterfaceClassName = ClassName.get(DAO_PACKAGE+".api", DATABASE_COMMON_INTERFACE_NAME);
     public static final TypeName sqliteOpenHelperClassName = ClassName.get("android.database.sqlite", "SQLiteOpenHelper");
     public static final TypeName contextClassName = ClassName.get("android.content", "Context");
     public static final TypeName cursorClassName = ClassName.get("android.database", "Cursor");

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Constants.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Constants.java
@@ -32,11 +32,11 @@ public class Constants {
     public static final TypeName daoClassName = ClassName.get(Constants.DAO_PACKAGE, DAO_CLASS_NAME);
     public static final TypeName dbHelperClassName = ClassName.get(Constants.DAO_PACKAGE, DATABASE_HELPER_CLASS_NAME);
     public static final TypeName queryBuilderClassName = ClassName.get(Constants.DAO_PACKAGE, QUERY_BUILDER_SUFFIX);
+    public static final TypeName databaseCommonInterfaceClassName = ClassName.get(Constants.DAO_PACKAGE, DATABASE_COMMON_INTERFACE_NAME);
     public static final TypeName migrator = ClassName.get(Constants.DAO_PACKAGE+".migration", MIGRATOR);
 
     public static final TypeName applicationClassName = ClassName.get("android.app", "Application");
     public static final TypeName databaseClassName = ClassName.get("android.database.sqlite", "SQLiteDatabase");
-    public static final TypeName databaseCommonInterfaceClassName = ClassName.get(DAO_PACKAGE+".api", DATABASE_COMMON_INTERFACE_NAME);
     public static final TypeName sqliteOpenHelperClassName = ClassName.get("android.database.sqlite", "SQLiteOpenHelper");
     public static final TypeName contextClassName = ClassName.get("android.content", "Context");
     public static final TypeName cursorClassName = ClassName.get("android.database", "Cursor");

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Processor.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/Processor.java
@@ -3,6 +3,15 @@ package com.github.florent37.rxandroidorm;
 import com.github.florent37.rxandroidorm.annotations.DatabaseName;
 import com.github.florent37.rxandroidorm.annotations.Migration;
 import com.github.florent37.rxandroidorm.annotations.Model;
+import com.github.florent37.rxandroidorm.generator.CursorHelperGenerator;
+import com.github.florent37.rxandroidorm.generator.DatabaseHelperGenerator;
+import com.github.florent37.rxandroidorm.generator.EnumColumnGenerator;
+import com.github.florent37.rxandroidorm.generator.ModelEntityProxyGenerator;
+import com.github.florent37.rxandroidorm.generator.ModelORMGenerator;
+import com.github.florent37.rxandroidorm.generator.ModelORMInterfaceGenerator;
+import com.github.florent37.rxandroidorm.generator.PrimitiveCursorHelperGenerator;
+import com.github.florent37.rxandroidorm.generator.QueryBuilderGenerator;
+import com.github.florent37.rxandroidorm.generator.QueryLoggerGenerator;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
@@ -24,15 +33,6 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
-
-import com.github.florent37.rxandroidorm.generator.CursorHelperGenerator;
-import com.github.florent37.rxandroidorm.generator.DatabaseHelperGenerator;
-import com.github.florent37.rxandroidorm.generator.EnumColumnGenerator;
-import com.github.florent37.rxandroidorm.generator.ModelEntityProxyGenerator;
-import com.github.florent37.rxandroidorm.generator.ModelORMGenerator;
-import com.github.florent37.rxandroidorm.generator.PrimitiveCursorHelperGenerator;
-import com.github.florent37.rxandroidorm.generator.QueryBuilderGenerator;
-import com.github.florent37.rxandroidorm.generator.QueryLoggerGenerator;
 
 /**
  * Created by florentchampigny on 07/01/2016.
@@ -82,6 +82,7 @@ public class Processor extends AbstractProcessor {
         writeFile(JavaFile.builder(Constants.DAO_PACKAGE, ModelEntityProxyGenerator.generateModelProxyInterface()).build());
         writeFile(JavaFile.builder(Constants.DAO_PACKAGE, new PrimitiveCursorHelperGenerator().generate()).build());
         writeFile(JavaFile.builder(Constants.DAO_PACKAGE, new QueryBuilderGenerator().generate()).build());
+        writeFile(JavaFile.builder(Constants.DAO_PACKAGE, new ModelORMInterfaceGenerator().generate()).build());
     }
 
     protected void writeJavaFiles() {
@@ -177,5 +178,9 @@ public class Processor extends AbstractProcessor {
         writeFile(JavaFile.builder(ProcessUtils.getObjectPackage(element), modelORMGenerator.getQueryBuilder()).build());
 
         daosList.add(ProcessUtils.getModelDao(element));
+    }
+
+    private void generateModelDaoInterface() {
+        ModelORMInterfaceGenerator modelORMInterfaceGenerator = new ModelORMInterfaceGenerator();
     }
 }

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMGenerator.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMGenerator.java
@@ -361,6 +361,7 @@ public class ModelORMGenerator {
                 //        .build())
 
                 .addMethod(MethodSpec.methodBuilder("select")
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .returns(queryBuilderClassName)
                         .addStatement("return new $T(false,logger)", queryBuilderClassName)

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMGenerator.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMGenerator.java
@@ -1,5 +1,7 @@
 package com.github.florent37.rxandroidorm.generator;
 
+import com.github.florent37.rxandroidorm.Constants;
+import com.github.florent37.rxandroidorm.ProcessUtils;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
@@ -16,9 +18,6 @@ import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
-
-import com.github.florent37.rxandroidorm.Constants;
-import com.github.florent37.rxandroidorm.ProcessUtils;
 
 import io.reactivex.ObservableEmitter;
 
@@ -331,6 +330,8 @@ public class ModelORMGenerator {
                 .build();
 
         this.dao = TypeSpec.classBuilder(ProcessUtils.getModelDaoName(modelName)) //UserDatabase
+                .addSuperinterface(ParameterizedTypeName.get((ClassName) Constants.databaseCommonInterfaceClassName, modelClassName))
+
                 .addModifiers(Modifier.PUBLIC)
 
                 .addField(ClassName.get(Constants.DAO_PACKAGE, Constants.QUERY_LOGGER), "logger")
@@ -373,6 +374,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("add")
+                        .addAnnotation(Override.class)
                         .addParameter(modelClassName, "object", Modifier.FINAL)
                         .returns(ProcessUtils.observableOf(modelClassName))
                         .addModifiers(Modifier.PUBLIC)
@@ -391,6 +393,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("add")
+                        .addAnnotation(Override.class)
                         .returns(ProcessUtils.observableOf(listObjectsClassName))
                         .addParameter(listObjectsClassName, "objects", Modifier.FINAL)
                         .addModifiers(Modifier.PUBLIC)
@@ -413,6 +416,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("update")
+                        .addAnnotation(Override.class)
                         .addParameter(modelClassName, "object", Modifier.FINAL)
                         .returns(ProcessUtils.observableOf(modelClassName))
                         .addModifiers(Modifier.PUBLIC)
@@ -431,6 +435,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("update")
+                        .addAnnotation(Override.class)
                         .returns(ProcessUtils.observableOf(listObjectsClassName))
                         .addParameter(listObjectsClassName, "objects", Modifier.FINAL)
                         .addModifiers(Modifier.PUBLIC)
@@ -481,6 +486,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("delete")
+                        .addAnnotation(Override.class)
                         .addParameter(modelClassName, "object", Modifier.FINAL)
                         .addModifiers(Modifier.PUBLIC)
                         .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
@@ -499,6 +505,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("delete")
+                        .addAnnotation(Override.class)
                         .addParameter(listObjectsClassName, "objects", Modifier.FINAL)
                         .addModifiers(Modifier.PUBLIC)
                         .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
@@ -519,6 +526,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("deleteAll")
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
 
@@ -536,6 +544,7 @@ public class ModelORMGenerator {
                         .build())
 
                 .addMethod(MethodSpec.methodBuilder("count")
+                        .addAnnotation(Override.class)
                         .addModifiers(Modifier.PUBLIC)
                         .returns(ProcessUtils.observableOf(TypeName.INT.box()))
 

--- a/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMInterfaceGenerator.java
+++ b/rxandroidorm-compiler/src/main/java/com/github/florent37/rxandroidorm/generator/ModelORMInterfaceGenerator.java
@@ -1,0 +1,88 @@
+package com.github.florent37.rxandroidorm.generator;
+
+import com.github.florent37.rxandroidorm.Constants;
+import com.github.florent37.rxandroidorm.ProcessUtils;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
+
+import javax.lang.model.element.Modifier;
+
+/**
+ * Created by Thibaud Giovannetti on 09/05/2017.
+ */
+public class ModelORMInterfaceGenerator {
+
+    public ModelORMInterfaceGenerator() {
+
+    }
+
+    public TypeSpec generate() {
+        final TypeVariableName T = TypeVariableName.get("T");
+        final TypeName LIST_OF_T = ParameterizedTypeName.get(ClassName.get("java.util", "List"), T);
+
+        final TypeName RETURN_T = ProcessUtils.observableOf(T);
+        final TypeName RETURN_LIST_T = ProcessUtils.observableOf(LIST_OF_T);
+
+        return TypeSpec.interfaceBuilder(Constants.DATABASE_COMMON_INTERFACE_NAME)
+                .addModifiers(Modifier.PUBLIC)
+                .addTypeVariable(T)
+
+
+                .addMethod(MethodSpec.methodBuilder("select")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(Constants.queryBuilderClassName)
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("add")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(T, "object", Modifier.FINAL)
+                        .returns(RETURN_T)
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("add")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(LIST_OF_T, "objects", Modifier.FINAL)
+                        .returns(RETURN_LIST_T)
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("update")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(T, "object", Modifier.FINAL)
+                        .returns(RETURN_T)
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("update")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(LIST_OF_T, "objects", Modifier.FINAL)
+                        .returns(RETURN_LIST_T)
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("delete")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(T, "object", Modifier.FINAL)
+                        .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("delete")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addParameter(LIST_OF_T, "objects", Modifier.FINAL)
+                        .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("deleteAll")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(ProcessUtils.observableOf(TypeName.BOOLEAN.box()))
+                        .build())
+
+                .addMethod(MethodSpec.methodBuilder("count")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(ProcessUtils.observableOf(TypeName.INT.box()))
+                        .build())
+
+                .build();
+    }
+}

--- a/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
+++ b/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
@@ -5,9 +5,9 @@ import java.util.List;
 import io.reactivex.Observable;
 
 /**
+ * Common interface for Database
  * Created by thibaud on 09/05/2017.
  */
-
 public interface Database<T> {
     Observable<T> add(final T object);
 

--- a/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
+++ b/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
@@ -1,5 +1,4 @@
 package com.github.florent37.rxandroidorm.api;
-
 import java.util.List;
 
 import io.reactivex.Observable;

--- a/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
+++ b/rxandroidorm/src/main/java/com/github/florent37/rxandroidorm/api/Database.java
@@ -1,0 +1,27 @@
+package com.github.florent37.rxandroidorm.api;
+
+import java.util.List;
+
+import io.reactivex.Observable;
+
+/**
+ * Created by thibaud on 09/05/2017.
+ */
+
+public interface Database<T> {
+    Observable<T> add(final T object);
+
+    Observable<List<T>> add(final List<T> objects);
+
+    Observable<T> update(final T object);
+
+    Observable<List<T>> update(final List<T> objects);
+
+    Observable<Boolean> delete(final T object);
+
+    Observable<Boolean> delete(final List<T> objects);
+
+    Observable<Boolean> deleteAll();
+
+    Observable<Integer> count();
+}


### PR DESCRIPTION
Fix #1 

- Add a common interface on all generated databases classes through a new generator.
- Increase the gradle tool from 2.2.3 to version 2.3.0

This PR is divided into 2 parts; first I tried to make a static interface in your library. Then, because the QueryBuilder is generated, I had to move everything into a new generator to add abstract select() method.